### PR TITLE
Folder rewrite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ before_script:
 - "./cc-test-reporter before-build"
 script:
 - rake mock
+- echo "TEMP,TMP,TMPDIR='$TEMP' '$TMP' '$TMPDIR'"
+- sudo su -l $USER -c "echo \"(su) TEMP,TMP,TMPDIR='$TEMP' '$TMP' '$TMPDIR'\""
 - sudo su -l $USER -c "cd $(pwd) && rvm use ${RUBY_VERSION/ruby-/} && rake spec"
 after_script:
 - cat Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ before_script:
 - "./cc-test-reporter before-build"
 script:
 - rake mock
-- echo "TEMP,TMP,TMPDIR='$TEMP' '$TMP' '$TMPDIR'"
-- sudo su -l $USER -c "echo \"(su) TEMP,TMP,TMPDIR='$TEMP' '$TMP' '$TMPDIR'\""
+- mktemp
 - sudo su -l $USER -c "cd $(pwd) && rvm use ${RUBY_VERSION/ruby-/} && rake spec"
 after_script:
 - cat Gemfile.lock

--- a/lib/nexussw/lxd/transport.rb
+++ b/lib/nexussw/lxd/transport.rb
@@ -45,7 +45,10 @@ module NexusSW
       end
 
       def self.local_tempdir
-        ENV['TEMP'] || ENV['TMP'] || ENV['TMPDIR'] || '/tmp'
+        return ENV['TEMP'] unless ENV['TEMP'].empty?
+        return ENV['TMP'] unless ENV['TMP'].empty?
+        return ENV['TMPDIR'] unless ENV['TMPDIR'].empty?
+        '/tmp'
       end
     end
   end

--- a/lib/nexussw/lxd/transport.rb
+++ b/lib/nexussw/lxd/transport.rb
@@ -37,11 +37,15 @@ module NexusSW
       end
 
       # kludge for windows environment
-      def self.tempname(basename)
+      def self.remote_tempname(basename)
         tfile = Tempfile.new(basename)
         "/tmp/#{File.basename tfile.path}"
       ensure
         tfile.unlink
+      end
+
+      def self.local_tempdir
+        Gem.win_platform? ? ENV['TEMP'] : '/tmp'
       end
     end
   end

--- a/lib/nexussw/lxd/transport.rb
+++ b/lib/nexussw/lxd/transport.rb
@@ -45,7 +45,7 @@ module NexusSW
       end
 
       def self.local_tempdir
-        Gem.win_platform? ? ENV['TEMP'] : '/tmp'
+        ENV['TEMP'] || ENV['TMP'] || ENV['TMPDIR'] || '/tmp'
       end
     end
   end

--- a/lib/nexussw/lxd/transport.rb
+++ b/lib/nexussw/lxd/transport.rb
@@ -45,9 +45,9 @@ module NexusSW
       end
 
       def self.local_tempdir
-        return ENV['TEMP'] unless ENV['TEMP'].empty?
-        return ENV['TMP'] unless ENV['TMP'].empty?
-        return ENV['TMPDIR'] unless ENV['TMPDIR'].empty?
+        return ENV['TEMP'] unless !ENV['TEMP'] || ENV['TEMP'].empty?
+        return ENV['TMP'] unless !ENV['TMP'] || ENV['TMP'].empty?
+        return ENV['TMPDIR'] unless !ENV['TMPDIR'] || ENV['TMPDIR'].empty?
         '/tmp'
       end
     end

--- a/lib/nexussw/lxd/transport.rb
+++ b/lib/nexussw/lxd/transport.rb
@@ -23,6 +23,10 @@ module NexusSW
         raise "#{self.class}#download_file not implemented"
       end
 
+      def download_folder(_path, _local_path)
+        raise "#{self.class}#download_folder not implemented"
+      end
+
       def upload_file(_local_path, _path, _options = {})
         raise "#{self.class}#upload_file not implemented"
       end

--- a/lib/nexussw/lxd/transport.rb
+++ b/lib/nexussw/lxd/transport.rb
@@ -1,4 +1,5 @@
 require 'nexussw/lxd'
+require 'tempfile'
 
 module NexusSW
   module LXD
@@ -33,6 +34,14 @@ module NexusSW
 
       def upload_folder(_local_path, _path, _options = {})
         raise "#{self.class}#upload_folder not implemented"
+      end
+
+      # kludge for windows environment
+      def self.tempname(basename)
+        tfile = Tempfile.new(basename)
+        "/tmp/#{File.basename tfile.path}"
+      ensure
+        tfile.unlink
       end
     end
   end

--- a/lib/nexussw/lxd/transport/mixins/cli.rb
+++ b/lib/nexussw/lxd/transport/mixins/cli.rb
@@ -33,7 +33,7 @@ module NexusSW
           end
 
           def read_file(path)
-            tfile = Transport.tempname(container_name)
+            tfile = Transport.remote_tempname(container_name)
             retval = execute("#{@container_name}#{path} #{tfile}", subcommand: 'file pull', capture: false)
             # return '' if retval.exitstatus == 1
             retval.error!
@@ -45,7 +45,7 @@ module NexusSW
           def write_file(path, content, options = {})
             perms = file_perms(options)
 
-            tfile = Transport.tempname(container_name)
+            tfile = Transport.remote_tempname(container_name)
             inner_transport.write_file tfile, content
             execute("#{tfile} #{container_name}#{path}", subcommand: "file push#{perms}", capture: false).error!
           ensure
@@ -53,7 +53,7 @@ module NexusSW
           end
 
           def download_file(path, local_path)
-            tfile = Transport.tempname(container_name) if punt
+            tfile = Transport.remote_tempname(container_name) if punt
             localname = tfile || local_path
             execute("#{container_name}#{path} #{localname}", subcommand: 'file pull', capture: false).error!
             inner_transport.download_file tfile, local_path if tfile
@@ -64,7 +64,7 @@ module NexusSW
           def upload_file(local_path, path, options = {})
             perms = file_perms(options)
 
-            tfile = Transport.tempname(container_name) if punt
+            tfile = Transport.remote_tempname(container_name) if punt
             localname = tfile || local_path
             inner_transport.upload_file local_path, tfile if tfile
             execute("#{localname} #{container_name}#{path}", subcommand: "file push#{perms}", capture: false).error!

--- a/lib/nexussw/lxd/transport/mixins/cli.rb
+++ b/lib/nexussw/lxd/transport/mixins/cli.rb
@@ -1,6 +1,6 @@
 require 'nexussw/lxd/transport/mixins/local'
 require 'nexussw/lxd/transport/mixins/helpers/users'
-require 'nexussw/lxd/transport/mixins/helpers/upload_folder'
+require 'nexussw/lxd/transport/mixins/helpers/folder_txfr'
 require 'tempfile'
 require 'shellwords'
 
@@ -18,7 +18,7 @@ module NexusSW
 
           attr_reader :inner_transport, :punt, :container_name, :config
 
-          include Helpers::UploadFolder
+          include Helpers::FolderTxfr
           include Helpers::UsersMixin
 
           def execute(command, options = {}, &block)

--- a/lib/nexussw/lxd/transport/mixins/cli.rb
+++ b/lib/nexussw/lxd/transport/mixins/cli.rb
@@ -79,6 +79,12 @@ module NexusSW
             execute("-r #{local_path} #{container_name}#{path}", subcommand: "file push#{perms}", capture: false).error!
           end
 
+          def download_folder(path, local_path)
+            return super unless config[:info] && config[:info]['api_extensions'] && config[:info]['api_extensions'].include?('directory_manipulation')
+
+            execute("-r #{container_name}#{path} #{local_path}", subcommand: 'file pull', capture: false).error!
+          end
+
           def add_remote(host_name)
             execute("add #{host_name} --accept-certificate", subcommand: 'remote').error! unless remote? host_name
           end

--- a/lib/nexussw/lxd/transport/mixins/cli.rb
+++ b/lib/nexussw/lxd/transport/mixins/cli.rb
@@ -55,7 +55,7 @@ module NexusSW
           def download_file(path, local_path)
             tfile = Transport.remote_tempname(container_name) if punt
             localname = tfile || local_path
-            execute("#{container_name}#{path} #{localname}", subcommand: 'file pull', capture: false).error!
+            execute("#{container_name}#{path} #{localname}", subcommand: 'file pull').error!
             inner_transport.download_file tfile, local_path if tfile
           ensure
             inner_transport.execute("rm -rf #{tfile}", capture: false) if tfile
@@ -67,7 +67,7 @@ module NexusSW
             tfile = Transport.remote_tempname(container_name) if punt
             localname = tfile || local_path
             inner_transport.upload_file local_path, tfile if tfile
-            execute("#{localname} #{container_name}#{path}", subcommand: "file push#{perms}", capture: false).error!
+            execute("#{localname} #{container_name}#{path}", subcommand: "file push#{perms}").error!
           ensure
             inner_transport.execute("rm -rf #{tfile}", capture: false) if tfile
           end

--- a/lib/nexussw/lxd/transport/mixins/helpers/folder_txfr.rb
+++ b/lib/nexussw/lxd/transport/mixins/helpers/folder_txfr.rb
@@ -44,7 +44,13 @@ module NexusSW
 
               download_file tfile, tarball_name
 
-              Archive::Tar::Minitar.unpack Zlib::GzipReader.new(File.open(tarball_name, 'rb')), File.dirname(local_path)
+              # if Gem.win_platform?
+              Archive::Tar::Minitar.unpack Zlib::GzipReader.new(File.open(tarball_name, 'rb')), local_path
+              # else
+              #   Dir.chdir File.dirname(local_path) do
+              #     `tar xvf #{tarball_name}`
+              #   end
+              # end
             ensure
               if tarball_name
                 File.delete tarball_name if File.exist? tarball_name

--- a/lib/nexussw/lxd/transport/mixins/helpers/folder_txfr.rb
+++ b/lib/nexussw/lxd/transport/mixins/helpers/folder_txfr.rb
@@ -38,8 +38,8 @@ module NexusSW
             # gzip(-z) or bzip2(-j) (these are the only 2 on trusty atm)
             def download_using_tarball(path, local_path)
               return false unless can_archive?
-              tfile = Transport.tempname(container_name)
-              tarball_name = File.join Dir.tmpdir, File.basename(tfile) + '.tgz'
+              tfile = Transport.remote_tempname(container_name)
+              tarball_name = File.join Transport.local_tempdir, File.basename(tfile) + '.tgz'
               execute("tar -czf #{tfile} -C #{File.dirname path} ./#{File.basename path}").error!
 
               download_file tfile, tarball_name

--- a/lib/nexussw/lxd/transport/mixins/helpers/folder_txfr.rb
+++ b/lib/nexussw/lxd/transport/mixins/helpers/folder_txfr.rb
@@ -37,8 +37,21 @@ module NexusSW
 
             # gzip(-z) or bzip2(-j) (these are the only 2 on trusty atm)
             def download_using_tarball(path, local_path)
-              return false # unless can_archive?
-              raise 'ENOIMPL tarball'
+              return false unless can_archive?
+              tfile = Transport.tempname(container_name)
+              tarball_name = File.join Dir.tmpdir, File.basename(tfile) + '.tgz'
+              execute("tar -czf #{tfile} -C #{File.dirname path} ./#{File.basename path}").error!
+
+              download_file tfile, tarball_name
+
+              Dir.chdir File.dirname(local_path) do
+                Archive::Tar::Minitar.unpack Zlib::GzipReader.new(File.open(tarball_name, 'rb')), '.'
+              end
+            ensure
+              if tarball_name
+                File.delete tarball_name if File.exist? tarball_name
+                execute "rm -rf #{tfile}"
+              end
             end
 
             def upload_using_tarball(local_path, path, options = {})

--- a/lib/nexussw/lxd/transport/mixins/helpers/folder_txfr.rb
+++ b/lib/nexussw/lxd/transport/mixins/helpers/folder_txfr.rb
@@ -3,7 +3,7 @@ module NexusSW
     class Transport
       module Mixins
         module Helpers
-          module UploadFolder
+          module FolderTxfr
             def upload_folder(local_path, path, options = {})
               upload_using_tarball(local_path, path, options) || upload_files_individually(local_path, path, options)
             end

--- a/lib/nexussw/lxd/transport/mixins/helpers/folder_txfr.rb
+++ b/lib/nexussw/lxd/transport/mixins/helpers/folder_txfr.rb
@@ -17,7 +17,7 @@ module NexusSW
 
             def upload_files_individually(local_path, path, options = {})
               dest = File.join(path, File.basename(local_path))
-              execute 'mkdir -p ' + dest, capture: false # for parity with tarball extract
+              execute('mkdir -p ' + dest).error! # for parity with tarball extract
               Dir.entries(local_path).map { |f| (f == '.' || f == '..') ? nil : File.join(local_path, f) }.compact.each do |f|
                 upload_files_individually f, dest, options if File.directory? f
                 upload_file f, File.join(dest, File.basename(f)), options if File.file? f
@@ -44,13 +44,7 @@ module NexusSW
 
               download_file tfile, tarball_name
 
-              # if Gem.win_platform?
               Archive::Tar::Minitar.unpack Zlib::GzipReader.new(File.open(tarball_name, 'rb')), local_path
-              # else
-              #   Dir.chdir File.dirname(local_path) do
-              #     `tar xvf #{tarball_name}`
-              #   end
-              # end
             ensure
               if tarball_name
                 File.delete tarball_name if File.exist? tarball_name

--- a/lib/nexussw/lxd/transport/mixins/helpers/folder_txfr.rb
+++ b/lib/nexussw/lxd/transport/mixins/helpers/folder_txfr.rb
@@ -40,13 +40,11 @@ module NexusSW
               return false unless can_archive?
               tfile = Transport.remote_tempname(container_name)
               tarball_name = File.join Transport.local_tempdir, File.basename(tfile) + '.tgz'
-              execute("tar -czf #{tfile} -C #{File.dirname path} ./#{File.basename path}").error!
+              execute("tar -czf #{tfile} -C #{File.dirname path} #{File.basename path}").error!
 
               download_file tfile, tarball_name
 
-              Dir.chdir File.dirname(local_path) do
-                Archive::Tar::Minitar.unpack Zlib::GzipReader.new(File.open(tarball_name, 'rb')), '.'
-              end
+              Archive::Tar::Minitar.unpack Zlib::GzipReader.new(File.open(tarball_name, 'rb')), File.dirname(local_path)
             ensure
               if tarball_name
                 File.delete tarball_name if File.exist? tarball_name

--- a/lib/nexussw/lxd/transport/mixins/rest.rb
+++ b/lib/nexussw/lxd/transport/mixins/rest.rb
@@ -1,6 +1,6 @@
 require 'nexussw/lxd/transport/mixins/helpers/execute'
 require 'nexussw/lxd/transport/mixins/helpers/users'
-require 'nexussw/lxd/transport/mixins/helpers/upload_folder'
+require 'nexussw/lxd/transport/mixins/helpers/folder_txfr'
 require 'nio/websocket'
 require 'tempfile'
 require 'json'
@@ -23,7 +23,7 @@ module NexusSW
           attr_reader :api, :rest_endpoint, :container_name, :config
 
           include Helpers::ExecuteMixin
-          include Helpers::UploadFolder
+          include Helpers::FolderTxfr
           include Helpers::UsersMixin
 
           class StdinStub

--- a/lxd-common.gemspec
+++ b/lxd-common.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '~> 0.13'
   spec.add_dependency 'nio4r-websocket', '~> 0.6'
-  spec.add_dependency 'minitar', '~> 0.5'
+  spec.add_dependency 'minitar', '~> 0.5.4'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lxd-common.gemspec
+++ b/lxd-common.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '~> 0.13'
   spec.add_dependency 'nio4r-websocket', '~> 0.6'
-  spec.add_dependency 'minitar', '~> 0.5.4'
+  spec.add_dependency 'minitar', '~> 0.5'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lxd-common.gemspec
+++ b/lxd-common.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '~> 0.13'
   spec.add_dependency 'nio4r-websocket', '~> 0.6'
+  spec.add_dependency 'minitar', '~> 0.5'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/spec/support/mock_transport.rb
+++ b/spec/support/mock_transport.rb
@@ -108,7 +108,13 @@ module NexusSW
                     # pp 'subcommand:', subcommand
                     return execute_chunked(subcommand, options.merge(hostcontainer: args[2]), &block)
                   elsif block_given? # rubocop:disable Metrics/BlockNesting
-                    yield '/'
+                    if command[/find -type d/] # rubocop:disable Metrics/BlockNesting
+                      yield ".\n./support\n"
+                    elsif command[/find ! -type d/] # rubocop:disable Metrics/BlockNesting
+                      yield "./support/shared_contexts.rb\n"
+                    else
+                      yield '/'
+                    end
                   end
                 end
               when 'start'

--- a/spec/support/mock_transport.rb
+++ b/spec/support/mock_transport.rb
@@ -1,5 +1,5 @@
 require 'nexussw/lxd/transport/mixins/helpers/execute'
-require 'nexussw/lxd/transport/mixins/helpers/upload_folder'
+require 'nexussw/lxd/transport/mixins/helpers/folder_txfr'
 require 'spec_helper'
 require 'yaml'
 require 'shellwords'
@@ -28,7 +28,7 @@ module NexusSW
         end
 
         include Mixins::Helpers::ExecuteMixin
-        include Mixins::Helpers::UploadFolder
+        include Mixins::Helpers::FolderTxfr
 
         def running_container_state
           {

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -69,6 +69,12 @@ shared_examples 'Transport Functions' do
     expect(transport.read_file('/root/spec/support/shared_contexts.rb')).to eq(File.read('spec/support/shared_contexts.rb'))
   end
 
+  it 'can download a folder' do
+    localname = File.join(ENV['TEMP'], 'spec')
+    expect { transport.download_folder('/root/spec', File.dirname(localname)) }.not_to raise_error
+    expect(File.read("#{localname}/support/shared_contexts.rb")).to eq(File.read('spec/support/shared_contexts.rb'))
+  end
+
   tfile = Tempfile.new 'lxd-rspec-tests'
   begin
     tfile.close

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -72,7 +72,7 @@ shared_examples 'Transport Functions' do
 
   it 'can download a folder' do
     begin
-      localname = File.join(Dir.tmpdir, 'spec')
+      localname = File.join(ENV['TEMP'], 'spec')
       expect { transport.download_folder('/root/spec', File.dirname(localname)) }.not_to raise_error
       expect(File.read(File.join(localname, 'support/shared_contexts.rb'))).to eq(File.read('spec/support/shared_contexts.rb'))
     ensure

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -70,9 +70,9 @@ shared_examples 'Transport Functions' do
   end
 
   it 'can download a folder' do
-    localname = File.join(ENV['TEMP'], 'spec')
+    localname = File.join(Dir.tmpdir, 'spec')
     expect { transport.download_folder('/root/spec', File.dirname(localname)) }.not_to raise_error
-    expect(File.read("#{localname}/support/shared_contexts.rb")).to eq(File.read('spec/support/shared_contexts.rb'))
+    expect(File.read(File.join(localname, 'support/shared_contexts.rb'))).to eq(File.read('spec/support/shared_contexts.rb'))
   end
 
   tfile = Tempfile.new 'lxd-rspec-tests'

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,4 +1,5 @@
 require 'tempfile'
+require 'fileutils'
 
 shared_examples 'it can create containers' do
   it 'detects a missing container' do
@@ -70,9 +71,13 @@ shared_examples 'Transport Functions' do
   end
 
   it 'can download a folder' do
-    localname = File.join(Dir.tmpdir, 'spec')
-    expect { transport.download_folder('/root/spec', File.dirname(localname)) }.not_to raise_error
-    expect(File.read(File.join(localname, 'support/shared_contexts.rb'))).to eq(File.read('spec/support/shared_contexts.rb'))
+    begin
+      localname = File.join(Dir.tmpdir, 'spec')
+      expect { transport.download_folder('/root/spec', File.dirname(localname)) }.not_to raise_error
+      expect(File.read(File.join(localname, 'support/shared_contexts.rb'))).to eq(File.read('spec/support/shared_contexts.rb'))
+    ensure
+      FileUtils.rm_rf localname, secure: true
+    end
   end
 
   tfile = Tempfile.new 'lxd-rspec-tests'

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -72,7 +72,7 @@ shared_examples 'Transport Functions' do
 
   it 'can download a folder' do
     begin
-      localname = File.join(ENV['TEMP'], 'spec')
+      localname = File.join(::NexusSW::LXD::Transport.local_tempdir, 'spec')
       expect { transport.download_folder('/root/spec', File.dirname(localname)) }.not_to raise_error
       expect(File.read(File.join(localname, 'support/shared_contexts.rb'))).to eq(File.read('spec/support/shared_contexts.rb'))
     ensure


### PR DESCRIPTION
* use minitar instead of a conditional 'tar' shellout
        - tar would only work on windows given the chefdk (or some other impl) in the path
        - backup was to download each file one by one & recreate the directory structure (inefficient)
* add download_folder

both upload and download folder now have full tarball implementations as backup when a more efficient API interface is not available

(mock tests are keeping the file-by-file implementations covered)